### PR TITLE
Add light and dark theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,16 @@
   font-family: 'Ubuntu', sans-serif;
 }
 
+body.light {
+  background-color: #f5f7fa;
+  color: #1f1f1f;
+}
+
+body.dark {
+  background-color: #1e1e2f;
+  color: #f1f1f1;
+}
+
 /* .ant-btn {
   background-color: #d7c7f4 !important;
   border-color: #d7c7f4 !important;

--- a/src/AppWithTheme.js
+++ b/src/AppWithTheme.js
@@ -1,0 +1,36 @@
+import React, { useContext, useEffect } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { ConfigProvider, theme } from 'antd';
+import App from './App';
+import { ThemeContext } from './context/ThemeContext';
+
+export default function AppWithTheme() {
+  const { mode } = useContext(ThemeContext);
+  const isDark = mode === 'dark';
+
+  useEffect(() => {
+    document.body.className = isDark ? 'dark' : 'light';
+  }, [isDark]);
+
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: isDark ? theme.darkAlgorithm : theme.defaultAlgorithm,
+        token: {
+          colorPrimary: '#7f5af0',
+          fontFamily: 'Ubuntu',
+        },
+        components: {
+          Button: {
+            colorPrimary: '#7f5af0',
+            colorText: isDark ? '#f1f1f1' : '#1f1f1f',
+          },
+        },
+      }}
+    >
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ConfigProvider>
+  );
+}

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,9 +1,12 @@
 import { Button, Space } from 'antd';
 import { useNavigate } from 'react-router';
 import { FileAddOutlined } from "@ant-design/icons";
+import { useContext } from 'react';
+import { ThemeContext } from '../context/ThemeContext';
 
 function SideBar({ onNewChat }) {
     const navigate = useNavigate()
+    const { toggle, mode } = useContext(ThemeContext)
 
     const handleNewChatClick = () => {
         onNewChat();
@@ -12,14 +15,17 @@ function SideBar({ onNewChat }) {
 
     return (
         <Space direction='vertical' size="large" align='center' style={{ marginTop : '20px' }}>
-            <Button 
-                icon={<FileAddOutlined />} 
+            <Button
+                icon={<FileAddOutlined />}
                 onClick={handleNewChatClick}
             >
                 New Chat
             </Button>
             <Button type="primary" onClick={() => navigate('/past-coversation')}>
                 <strong style={{ color: "#414146" }}>Past Conversations</strong>
+            </Button>
+            <Button onClick={toggle}>
+                Switch to {mode === 'light' ? 'Dark' : 'Light'} Mode
             </Button>
         </Space >
     )

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,0 +1,20 @@
+import React, { createContext, useState } from 'react';
+
+export const ThemeContext = createContext({
+  mode: 'light',
+  toggle: () => {}
+});
+
+export default function ThemeProvider({ children }) {
+  const [mode, setMode] = useState('light');
+
+  const toggle = () => {
+    setMode((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
-import { ConfigProvider, theme } from 'antd';
-import { BrowserRouter } from 'react-router-dom';
+import AppWithTheme from './AppWithTheme';
+import ThemeProvider from './context/ThemeContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <ConfigProvider
-        theme={{
-          token: {
-            fontFamily: 'Ubuntu',
-            algorithm: theme.darkAlgorithm,
-          },
-          components: {
-            Button: {
-              colorPrimary: "#d7c7f4",
-              colorText: "black"
-            }
-          }
-        }}
-      >
-        <App />
-      </ConfigProvider>
-    </BrowserRouter>
+    <ThemeProvider>
+      <AppWithTheme />
+    </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- implement simple theming with light and dark modes
- add ThemeContext and AppWithTheme wrapper
- update sidebar with theme toggle
- style body for both themes

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4d6eaaf08326b8ab4a737d871d3d