### PR TITLE
Add light/dark theme switch

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,17 +4,18 @@ import './App.css'
 import NewPage from "./pages/NewPage";
 import { Route, Routes } from "react-router-dom";
 import PastConversation from "./pages/PastConversation";
-import { Col, Row } from "antd";
+import { Col, Row, ConfigProvider } from "antd";
 
 function App() {
   const [newChatKey, setNewChatKey] = useState(Date.now());
+  const { token } = ConfigProvider.useToken();
   
   const handleNewChat = () => {
     setNewChatKey(Date.now());
   }
 
   return (
-    <Row style={{ display: "flex", width: "100%" }}>
+    <Row style={{ display: "flex", width: "100%", minHeight: "100vh", background: token.colorBgBase, color: token.colorTextBase }}>
       <Col span={3}>
         <SideBar onNewChat={handleNewChat} />
       </Col>

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,9 +1,11 @@
-import { Button, Space } from 'antd';
+import { Button, Space, Switch } from 'antd';
 import { useNavigate } from 'react-router';
-import { FileAddOutlined } from "@ant-design/icons";
+import { FileAddOutlined, BulbOutlined } from "@ant-design/icons";
+import { useTheme } from '../contexts/ThemeContext';
 
 function SideBar({ onNewChat }) {
     const navigate = useNavigate()
+    const { theme, toggleTheme } = useTheme()
 
     const handleNewChatClick = () => {
         onNewChat();
@@ -12,8 +14,8 @@ function SideBar({ onNewChat }) {
 
     return (
         <Space direction='vertical' size="large" align='center' style={{ marginTop : '20px' }}>
-            <Button 
-                icon={<FileAddOutlined />} 
+            <Button
+                icon={<FileAddOutlined />}
                 onClick={handleNewChatClick}
             >
                 New Chat
@@ -21,6 +23,13 @@ function SideBar({ onNewChat }) {
             <Button type="primary" onClick={() => navigate('/past-coversation')}>
                 <strong style={{ color: "#414146" }}>Past Conversations</strong>
             </Button>
+            <Switch
+                checkedChildren={<BulbOutlined />}
+                unCheckedChildren={<BulbOutlined />}
+                checked={theme === 'dark'}
+                onChange={toggleTheme}
+                style={{ marginTop: '10px' }}
+            />
         </Space >
     )
 }

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,5 +1,5 @@
 import { Button, Space, Switch } from 'antd';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import { FileAddOutlined, BulbOutlined } from "@ant-design/icons";
 import { useTheme } from '../contexts/ThemeContext';
 

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export const ThemeContext = createContext({
+  theme: 'light',
+  toggleTheme: () => {}
+});
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  const toggleTheme = () => setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/index.js
+++ b/src/index.js
@@ -3,27 +3,59 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { ConfigProvider, theme } from 'antd';
 import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider, useTheme } from './contexts/ThemeContext';
+
+const ThemedConfigProvider = ({ children }) => {
+  const { theme: mode } = useTheme();
+
+  const lightTheme = {
+    token: {
+      fontFamily: 'Ubuntu',
+      colorPrimary: '#4a90e2',
+      colorBgBase: '#f5f5f5',
+      colorTextBase: '#000000'
+    },
+    algorithm: theme.defaultAlgorithm,
+    components: {
+      Button: {
+        colorPrimary: '#4a90e2',
+        colorText: '#fff'
+      }
+    }
+  };
+
+  const darkTheme = {
+    token: {
+      fontFamily: 'Ubuntu',
+      colorPrimary: '#4a90e2',
+      colorBgBase: '#1e1e1e',
+      colorTextBase: '#e0e0e0'
+    },
+    algorithm: theme.darkAlgorithm,
+    components: {
+      Button: {
+        colorPrimary: '#4a90e2',
+        colorText: '#fff'
+      }
+    }
+  };
+
+  return (
+    <ConfigProvider theme={mode === 'dark' ? darkTheme : lightTheme}>
+      {children}
+    </ConfigProvider>
+  );
+};
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <ConfigProvider
-        theme={{
-          token: {
-            fontFamily: 'Ubuntu',
-            algorithm: theme.darkAlgorithm,
-          },
-          components: {
-            Button: {
-              colorPrimary: "#d7c7f4",
-              colorText: "black"
-            }
-          }
-        }}
-      >
-        <App />
-      </ConfigProvider>
+      <ThemeProvider>
+        <ThemedConfigProvider>
+          <App />
+        </ThemedConfigProvider>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- introduce `ThemeContext` with light and dark modes
- theme Ant Design using selected mode
- add switch in sidebar to toggle theme
- colorize `App` container using theme tokens

## Testing
- `npm test -- --passWithNoTests --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684c505f536c8326a7fc671518e3df47