### PR TITLE
Add theme toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,16 @@
   font-family: 'Ubuntu', sans-serif;
 }
 
+body[data-theme='light'] {
+  background: #f5f5f5;
+  color: #000;
+}
+
+body[data-theme='dark'] {
+  background: #1a1a1a;
+  color: #fff;
+}
+
 /* .ant-btn {
   background-color: #d7c7f4 !important;
   border-color: #d7c7f4 !important;

--- a/src/App.js
+++ b/src/App.js
@@ -1,30 +1,59 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import SideBar from "./components/SideBar";
 import './App.css'
 import NewPage from "./pages/NewPage";
 import { Route, Routes } from "react-router-dom";
 import PastConversation from "./pages/PastConversation";
-import { Col, Row } from "antd";
+import { Col, Row, ConfigProvider, theme as antdTheme } from "antd";
 
 function App() {
   const [newChatKey, setNewChatKey] = useState(Date.now());
+  const [themeMode, setThemeMode] = useState("light");
+
+  const toggleTheme = () => {
+    setThemeMode((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  useEffect(() => {
+    document.body.dataset.theme = themeMode;
+  }, [themeMode]);
   
   const handleNewChat = () => {
     setNewChatKey(Date.now());
   }
 
   return (
-    <Row style={{ display: "flex", width: "100%" }}>
-      <Col span={3}>
-        <SideBar onNewChat={handleNewChat} />
-      </Col>
-      <Col span={21}>
-        <Routes>
-          <Route path="/" element={<NewPage key={newChatKey} style={{ flexGrow: 1 }} />} />
-          <Route path="/past-coversation" element={<PastConversation />} />
-        </Routes>
-      </Col>
-    </Row>
+    <ConfigProvider
+      theme={{
+        algorithm:
+          themeMode === "dark"
+            ? antdTheme.darkAlgorithm
+            : antdTheme.defaultAlgorithm,
+        token: {
+          colorPrimary: "#8a2be2",
+          fontFamily: "Ubuntu",
+        },
+      }}
+    >
+      <Row style={{ display: "flex", width: "100%" }}>
+        <Col span={3}>
+          <SideBar
+            onNewChat={handleNewChat}
+            onToggleTheme={toggleTheme}
+            themeMode={themeMode}
+          />
+        </Col>
+        <Col span={21}>
+          <Routes>
+            <Route
+              path="/"
+              element={<NewPage key={newChatKey} style={{ flexGrow: 1 }} />}
+            />
+            <Route path="/past-coversation" element={<PastConversation />} />
+          </Routes>
+        </Col>
+      </Row>
+    </ConfigProvider>
   );
 }
 

--- a/src/components/ConversationComp.js
+++ b/src/components/ConversationComp.js
@@ -110,4 +110,5 @@ function ConversationComp({ who, quesAns, time, updateRatingFeedback, rating, fe
     )
 }
 
-export default ConversationComp
+export default ConversationComp;
+

--- a/src/components/ConversationContainer.js
+++ b/src/components/ConversationContainer.js
@@ -56,7 +56,7 @@ function ConversationContainer() {
       }}
     >
       <Flex style={{ flexGrow: 1 }} vertical justify="space-between">
-        <Space style={{ justifyContent: "space-between" }}>
+        <Flex justify="space-between" align="center">
           <Typography.Title level={4} style={{ color: "#9785BA" }}>
             Bot AI
           </Typography.Title>
@@ -94,7 +94,7 @@ function ConversationContainer() {
                   ))}
             </Select>
           </Space>
-        </Space>
+        </Flex>
         {currentSession.length ? (
           <Flex vertical justify="flex-start">
             {currentSession.map((item) => (

--- a/src/components/ConversationStarter.js
+++ b/src/components/ConversationStarter.js
@@ -8,4 +8,4 @@ function ConversationStarter({ question, subtext, onAsk }) {
     )
 }
 
-export default ConversationStarter
+export default ConversationStarter;

--- a/src/components/InputBar.js
+++ b/src/components/InputBar.js
@@ -29,4 +29,4 @@ function InputBar({ inputText, setInputText, onAsk, onSave }) {
     )
 }
 
-export default InputBar
+export default InputBar;

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -1,8 +1,8 @@
-import { Button, Space } from 'antd';
-import { useNavigate } from 'react-router';
+import { Button, Space, Switch } from 'antd';
+import { useNavigate } from 'react-router-dom';
 import { FileAddOutlined } from "@ant-design/icons";
 
-function SideBar({ onNewChat }) {
+function SideBar({ onNewChat, onToggleTheme, themeMode }) {
     const navigate = useNavigate()
 
     const handleNewChatClick = () => {
@@ -12,8 +12,8 @@ function SideBar({ onNewChat }) {
 
     return (
         <Space direction='vertical' size="large" align='center' style={{ marginTop : '20px' }}>
-            <Button 
-                icon={<FileAddOutlined />} 
+            <Button
+                icon={<FileAddOutlined />}
                 onClick={handleNewChatClick}
             >
                 New Chat
@@ -21,8 +21,14 @@ function SideBar({ onNewChat }) {
             <Button type="primary" onClick={() => navigate('/past-coversation')}>
                 <strong style={{ color: "#414146" }}>Past Conversations</strong>
             </Button>
+            <Switch
+                checked={themeMode === 'dark'}
+                onChange={onToggleTheme}
+                checkedChildren="Dark"
+                unCheckedChildren="Light"
+            />
         </Space >
     )
 }
 
-export default SideBar
+export default SideBar;

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { ConfigProvider, theme } from 'antd';
 import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <ConfigProvider
-        theme={{
-          token: {
-            fontFamily: 'Ubuntu',
-            algorithm: theme.darkAlgorithm,
-          },
-          components: {
-            Button: {
-              colorPrimary: "#d7c7f4",
-              colorText: "black"
-            }
-          }
-        }}
-      >
-        <App />
-      </ConfigProvider>
+      <App />
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/NewPage.js
+++ b/src/pages/NewPage.js
@@ -6,4 +6,4 @@ function NewPage({style}){
     )
 }
 
-export default NewPage
+export default NewPage;

--- a/src/pages/PastConversation.js
+++ b/src/pages/PastConversation.js
@@ -40,4 +40,4 @@ function PastConversation() {
     )
 }
 
-export default PastConversation
+export default PastConversation;


### PR DESCRIPTION
## Summary
- implement light and dark theme switch via Ant Design `ConfigProvider`
- add theme toggle switch to sidebar
- tweak conversation header layout
- set page background colors for light/dark modes

## Testing
- `npm test --silent --maxWorkers=50` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6359a174832689ca2fd37841b73d