### PR TITLE
Improve responsive UI layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,11 @@
   font-family: 'Ubuntu', sans-serif;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 body[data-theme='light'] {
   --bg-body: #f5f5f5;
   --text-color: #000;
@@ -30,6 +35,23 @@ body {
   color: var(--text-color);
 }
 
+.conversation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.model-selects {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.icon-wrapper img {
+  width: 100%;
+}
+
 .conversation-starters {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
@@ -42,6 +64,21 @@ body {
   .input-bar {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .conversation-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .model-selects > * {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .icon-wrapper {
+    width: 40px;
   }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -30,6 +30,21 @@ body {
   color: var(--text-color);
 }
 
+.conversation-starters {
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.input-bar {
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .input-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
 /* .ant-btn {
   background-color: #d7c7f4 !important;
   border-color: #d7c7f4 !important;

--- a/src/App.js
+++ b/src/App.js
@@ -47,15 +47,15 @@ function App() {
         token: tokens[themeMode],
       }}
     >
-      <Row style={{ display: "flex", width: "100%" }}>
-        <Col span={3}>
+      <Row style={{ display: "flex", width: "100%", minHeight: "100vh" }}>
+        <Col xs={24} md={6} lg={4}>
           <SideBar
             onNewChat={handleNewChat}
             onToggleTheme={toggleTheme}
             themeMode={themeMode}
           />
         </Col>
-        <Col span={21}>
+        <Col xs={24} md={18} lg={20}>
           <Routes>
             <Route
               path="/"

--- a/src/components/ConversationComp.js
+++ b/src/components/ConversationComp.js
@@ -66,7 +66,7 @@ function ConversationComp({ who, quesAns, time, updateRatingFeedback, rating, fe
             >
                 <TextArea autoSize onChange={(e) => updateRatingFeedback(time, rating, e.target.value)} />
             </Modal>
-            <div style={{ width: "80px" }}>
+            <div className="icon-wrapper" style={{ width: "80px" }}>
                 <img src={who === "user" ? userIcon : siteIcon} alt="user-icon" />
             </div>
             <Space direction="vertical">

--- a/src/components/ConversationContainer.js
+++ b/src/components/ConversationContainer.js
@@ -128,9 +128,9 @@ function ConversationContainer() {
               <img src={siteIcon} alt="site icon" />
             </Space>
             <Space
+              className="conversation-starters"
               style={{
                 display: "grid",
-                gridTemplateColumns: "1fr 1fr",
                 gap: "25px",
               }}
             >

--- a/src/components/ConversationContainer.js
+++ b/src/components/ConversationContainer.js
@@ -50,19 +50,19 @@ function ConversationContainer() {
         flexDirection: "column",
         justifyContent: "space-between",
         padding: "10px",
-        height: "100vh",
+        minHeight: "100vh",
         flexGrow: 1,
         gap: "50px",
       }}
     >
       <Flex style={{ flexGrow: 1 }} vertical justify="space-between">
-        <Flex justify="space-between" align="center">
+      <Flex className="conversation-header" justify="space-between" align="center">
           <Typography.Title level={4} style={{ color: "var(--primary-color)" }}>
             Bot AI
           </Typography.Title>
-          <Space>
+          <Space className="model-selects">
             <Select
-              style={{ width: 300 }}
+              style={{ minWidth: 150, flex: 1 }}
               value={selectedModelType}
               onChange={(value) => setSelectedModelType(value)}
             >
@@ -71,7 +71,7 @@ function ConversationContainer() {
               <Select.Option value="perplexity">Perplexity</Select.Option>
             </Select>
             <Select
-              style={{ width: 300 }}
+              style={{ minWidth: 150, flex: 1 }}
               value={selectedModel}
               onChange={(value) => setSelectedModel(value)}
             >

--- a/src/components/InputBar.js
+++ b/src/components/InputBar.js
@@ -3,7 +3,7 @@ import { Button, Input } from "antd"
 function InputBar({ inputText, setInputText, onAsk, onSave }) {
 
     return (
-        <div style={{ display: "flex", justifyContent: "space-between", gap: "10px", alignItems: "center" }}>
+        <div className="input-bar" style={{ display: "flex", justifyContent: "space-between", gap: "10px", alignItems: "center", flexWrap: "wrap" }}>
             <Input.TextArea
                 autoSize={{ minRows: 1, maxRows: 6 }}
                 onPressEnter={(e) => {


### PR DESCRIPTION
## Summary
- adjust main layout to use responsive grid breakpoints
- let conversation starters auto-fit columns
- allow input bar to wrap on small screens
- add responsive CSS helpers

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c6a99fbdc832697c1950126608dc1