### PR TITLE
Fix theme toggle and add code copy

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import PastConversation from "./pages/PastConversation";
 
 function App() {
   const [newChatKey, setNewChatKey] = useState(Date.now());
-  const [themeMode, setThemeMode] = useState("light");
+  const [themeMode, setThemeMode] = useState("dark");
 
 
   const toggleTheme = () => {
@@ -15,6 +15,11 @@ function App() {
 
   useEffect(() => {
     document.body.dataset.theme = themeMode;
+    if (themeMode === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
   }, [themeMode]);
   
   const handleNewChat = () => {

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -1,0 +1,38 @@
+import { ClipboardCopyIcon } from '@radix-ui/react-icons';
+import { useState } from 'react';
+
+function CodeBlock({ inline, className, children, ...props }) {
+  const [copied, setCopied] = useState(false);
+  const code = String(children).replace(/\n$/, '');
+
+  if (inline) {
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  }
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <pre className={className} {...props}>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="absolute top-1 right-1 p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        aria-label="Copy code"
+      >
+        {copied ? 'Copied!' : <ClipboardCopyIcon />}
+      </button>
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+export default CodeBlock;

--- a/src/components/ConversationComp.js
+++ b/src/components/ConversationComp.js
@@ -5,6 +5,7 @@ import siteIcon from "../assets/site-icon.png";
 import { useLocation } from "react-router";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import CodeBlock from "./CodeBlock";
 
 function parseThink(text) {
   const start = text.indexOf("<think>");
@@ -30,7 +31,7 @@ function parseThink(text) {
 function ConversationComp({ who, quesAns, time }) {
   const location = useLocation();
   const past = location.pathname === "/past-coversation";
-  const { reasoning, answer } = parseThink(quesAns);
+  const { reasoning, answer, inProgress } = parseThink(quesAns);
   const style = past
     ? ""
     : "bg-[var(--bubble-bg)] rounded shadow p-3 my-1";
@@ -50,38 +51,50 @@ function ConversationComp({ who, quesAns, time }) {
               onClick={() => setOpen((p) => !p)}
             >
               {open ? <MinusCircledIcon /> : <PlusCircledIcon />}
-              <svg
-                className="w-3 h-3 animate-spin ml-1 text-purple-600"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4l-3 3-3-3h4z"
-                />
-              </svg>
-              Thinking
+              {inProgress && (
+                <svg
+                  className="w-3 h-3 animate-spin ml-1 text-purple-600"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4l-3 3-3-3h4z"
+                  />
+                </svg>
+              )}
+              {open ? "Hide Analysis" : "Show Analysis"}
             </button>
             {open && (
-              <div className="mt-1 text-xs text-gray-800 dark:text-gray-200">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{reasoning}</ReactMarkdown>
+              <div className="mt-1 p-2 bg-[var(--card-bg)] rounded text-xs text-gray-800 dark:text-gray-200">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{ code: CodeBlock }}
+                >
+                  {reasoning}
+                </ReactMarkdown>
               </div>
             )}
           </div>
         )}
         {answer && (
           <div className="prose prose-sm dark:prose-invert">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer}</ReactMarkdown>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{ code: CodeBlock }}
+            >
+              {answer}
+            </ReactMarkdown>
           </div>
         )}
         <span className="text-xs text-gray-500">{time.split(",")[1]}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -11,20 +11,19 @@ body[data-theme='light'] {
 }
 
 pre {
-  @apply bg-gray-100 text-gray-800 rounded p-2 overflow-x-auto;
+  @apply relative bg-gray-100 text-gray-800 rounded p-2 overflow-x-auto;
 }
 
 code {
   @apply bg-gray-100 text-gray-800 rounded px-1;
 }
 
-@media (prefers-color-scheme: dark) {
-  pre {
-    @apply bg-gray-800 text-gray-100;
-  }
-  code {
-    @apply bg-gray-800 text-gray-100;
-  }
+body[data-theme='dark'] pre {
+  @apply bg-gray-800 text-gray-100;
+}
+
+body[data-theme='dark'] code {
+  @apply bg-gray-800 text-gray-100;
 }
 
 body[data-theme='dark'] {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
     "./public/index.html",


### PR DESCRIPTION
## Summary
- enable Tailwind class-based dark mode
- make dark theme the default
- sync theme state with the html `dark` class
- style code blocks per selected theme and add copy button
- show spinner only while reasoning is streaming

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684c8b408e008326a470ad1551ba734a