### PR TITLE
Improve UI for dark/light theme and code blocks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
     />
     <title>Bot AI</title>
   </head>
-  <body>
+  <body data-theme="dark">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import PastConversation from "./pages/PastConversation";
 
 function App() {
   const [newChatKey, setNewChatKey] = useState(Date.now());
-  const [themeMode, setThemeMode] = useState("light");
+  const [themeMode, setThemeMode] = useState("dark");
 
 
   const toggleTheme = () => {

--- a/src/components/ConversationComp.js
+++ b/src/components/ConversationComp.js
@@ -1,10 +1,37 @@
 import { useState } from "react";
-import { PlusCircledIcon, MinusCircledIcon } from "@radix-ui/react-icons";
+import { PlusCircledIcon, MinusCircledIcon, CopyIcon } from "@radix-ui/react-icons";
 import userIcon from "../assets/user-icon.png";
 import siteIcon from "../assets/site-icon.png";
 import { useLocation } from "react-router";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+
+const markdownComponents = {
+  code({ inline, className, children, ...props }) {
+    const code = String(children).replace(/\n$/, "");
+    if (inline) {
+      return (
+        <code className={className} {...props}>
+          {children}
+        </code>
+      );
+    }
+    return (
+      <div className="relative">
+        <button
+          className="absolute top-1 right-1 text-xs flex items-center gap-1 bg-gray-200 dark:bg-gray-700 px-1 rounded"
+          onClick={() => navigator.clipboard.writeText(code)}
+        >
+          <CopyIcon />
+          Copy
+        </button>
+        <pre>
+          <code className={className} {...props}>{children}</code>
+        </pre>
+      </div>
+    );
+  },
+};
 
 function parseThink(text) {
   const start = text.indexOf("<think>");
@@ -30,7 +57,7 @@ function parseThink(text) {
 function ConversationComp({ who, quesAns, time }) {
   const location = useLocation();
   const past = location.pathname === "/past-coversation";
-  const { reasoning, answer } = parseThink(quesAns);
+  const { reasoning, answer, inProgress } = parseThink(quesAns);
   const style = past
     ? ""
     : "bg-[var(--bubble-bg)] rounded shadow p-3 my-1";
@@ -46,42 +73,54 @@ function ConversationComp({ who, quesAns, time }) {
         {reasoning && (
           <div>
             <button
-              className="flex items-center gap-1 text-xs text-gray-800 dark:text-gray-300"
+              className="flex items-center gap-1 text-xs text-gray-900 dark:text-gray-300"
               onClick={() => setOpen((p) => !p)}
             >
               {open ? <MinusCircledIcon /> : <PlusCircledIcon />}
-              <svg
-                className="w-3 h-3 animate-spin ml-1 text-purple-600"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4l-3 3-3-3h4z"
-                />
-              </svg>
-              Thinking
+              {inProgress && (
+                <svg
+                  className="w-3 h-3 animate-spin ml-1 text-purple-600"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4l-3 3-3-3h4z"
+                  />
+                </svg>
+              )}
+              {inProgress ? "Thinking" : open ? "Hide Reasoning" : "Show Reasoning"}
             </button>
             {open && (
-              <div className="mt-1 text-xs text-gray-800 dark:text-gray-200">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{reasoning}</ReactMarkdown>
+              <div className="mt-1 text-xs text-gray-900 dark:text-gray-200">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={markdownComponents}
+                >
+                  {reasoning}
+                </ReactMarkdown>
               </div>
             )}
           </div>
         )}
         {answer && (
           <div className="prose prose-sm dark:prose-invert">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer}</ReactMarkdown>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={markdownComponents}
+            >
+              {answer}
+            </ReactMarkdown>
           </div>
         )}
         <span className="text-xs text-gray-500">{time.split(",")[1]}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@ body[data-theme='light'] {
   --primary-color: #722ed1;
   --card-bg: #f0e9fb;
   --bubble-bg: #eae5f3;
+  color-scheme: light;
 }
 
 pre {
@@ -33,6 +34,7 @@ body[data-theme='dark'] {
   --primary-color: #9254de;
   --card-bg: #1e1e1e;
   --bubble-bg: #262626;
+  color-scheme: dark;
 }
 
 body {


### PR DESCRIPTION
## Summary
- default to dark mode
- preserve color scheme variables for each theme
- show reasoning toggle without spinner once complete
- add copy button on code blocks
- set initial data-theme in `index.html`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b408e008326a470ad1551ba734a