### PR TITLE
Improve light mode UI and code blocks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import PastConversation from "./pages/PastConversation";
 
 function App() {
   const [newChatKey, setNewChatKey] = useState(Date.now());
-  const [themeMode, setThemeMode] = useState("light");
+  const [themeMode, setThemeMode] = useState("dark");
 
 
   const toggleTheme = () => {

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -1,0 +1,32 @@
+import { useState } from "react";
+
+function CodeBlock({ inline, className, children }) {
+  const [copied, setCopied] = useState(false);
+  const code = String(children).replace(/\n$/, "");
+
+  if (inline) {
+    return <code className={className}>{children}</code>;
+  }
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative">
+      <pre className={className}>
+        <code>{code}</code>
+      </pre>
+      <button
+        onClick={handleCopy}
+        className="absolute top-1 right-1 text-xs bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 px-1 rounded"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+export default CodeBlock;

--- a/src/components/ConversationComp.js
+++ b/src/components/ConversationComp.js
@@ -5,6 +5,7 @@ import siteIcon from "../assets/site-icon.png";
 import { useLocation } from "react-router";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import CodeBlock from "./CodeBlock";
 
 function parseThink(text) {
   const start = text.indexOf("<think>");
@@ -30,7 +31,7 @@ function parseThink(text) {
 function ConversationComp({ who, quesAns, time }) {
   const location = useLocation();
   const past = location.pathname === "/past-coversation";
-  const { reasoning, answer } = parseThink(quesAns);
+  const { reasoning, answer, inProgress } = parseThink(quesAns);
   const style = past
     ? ""
     : "bg-[var(--bubble-bg)] rounded shadow p-3 my-1";
@@ -50,38 +51,50 @@ function ConversationComp({ who, quesAns, time }) {
               onClick={() => setOpen((p) => !p)}
             >
               {open ? <MinusCircledIcon /> : <PlusCircledIcon />}
-              <svg
-                className="w-3 h-3 animate-spin ml-1 text-purple-600"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4l-3 3-3-3h4z"
-                />
-              </svg>
-              Thinking
+              {inProgress && (
+                <svg
+                  className="w-3 h-3 animate-spin ml-1 text-purple-600"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4l-3 3-3-3h4z"
+                  />
+                </svg>
+              )}
+              {inProgress ? "Thinking" : open ? "Hide Reasoning" : "Show Reasoning"}
             </button>
             {open && (
-              <div className="mt-1 text-xs text-gray-800 dark:text-gray-200">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{reasoning}</ReactMarkdown>
+              <div className="mt-1 text-xs bg-gray-100 dark:bg-gray-700 p-2 rounded text-gray-800 dark:text-gray-200">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{ code: CodeBlock }}
+                >
+                  {reasoning}
+                </ReactMarkdown>
               </div>
             )}
           </div>
         )}
         {answer && (
           <div className="prose prose-sm dark:prose-invert">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer}</ReactMarkdown>
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{ code: CodeBlock }}
+            >
+              {answer}
+            </ReactMarkdown>
           </div>
         )}
         <span className="text-xs text-gray-500">{time.split(",")[1]}</span>


### PR DESCRIPTION
## Summary
- default to dark theme on startup
- add reusable `CodeBlock` component with copy button
- show 'Show Reasoning' button with spinner only while reasoning
- style the reasoning dropdown for better readability

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b408e008326a470ad1551ba734a