### PR TITLE
Improve theme handling and code blocks

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import PastConversation from "./pages/PastConversation";
 
 function App() {
   const [newChatKey, setNewChatKey] = useState(Date.now());
-  const [themeMode, setThemeMode] = useState("light");
+  const [themeMode, setThemeMode] = useState("dark");
 
 
   const toggleTheme = () => {
@@ -15,6 +15,7 @@ function App() {
 
   useEffect(() => {
     document.body.dataset.theme = themeMode;
+    document.body.classList.toggle("dark", themeMode === "dark");
   }, [themeMode]);
   
   const handleNewChat = () => {

--- a/src/components/ConversationComp.js
+++ b/src/components/ConversationComp.js
@@ -3,8 +3,7 @@ import { PlusCircledIcon, MinusCircledIcon } from "@radix-ui/react-icons";
 import userIcon from "../assets/user-icon.png";
 import siteIcon from "../assets/site-icon.png";
 import { useLocation } from "react-router";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import Markdown from "./Markdown";
 
 function parseThink(text) {
   const start = text.indexOf("<think>");
@@ -30,7 +29,7 @@ function parseThink(text) {
 function ConversationComp({ who, quesAns, time }) {
   const location = useLocation();
   const past = location.pathname === "/past-coversation";
-  const { reasoning, answer } = parseThink(quesAns);
+  const { reasoning, answer, inProgress } = parseThink(quesAns);
   const style = past
     ? ""
     : "bg-[var(--bubble-bg)] rounded shadow p-3 my-1";
@@ -50,38 +49,40 @@ function ConversationComp({ who, quesAns, time }) {
               onClick={() => setOpen((p) => !p)}
             >
               {open ? <MinusCircledIcon /> : <PlusCircledIcon />}
-              <svg
-                className="w-3 h-3 animate-spin ml-1 text-purple-600"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4l-3 3-3-3h4z"
-                />
-              </svg>
-              Thinking
+              {inProgress && (
+                <svg
+                  className="w-3 h-3 animate-spin ml-1 text-purple-600"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4l-3 3-3-3h4z"
+                  />
+                </svg>
+              )}
+              {open ? "Hide Reasoning" : "Show Reasoning"}
             </button>
             {open && (
               <div className="mt-1 text-xs text-gray-800 dark:text-gray-200">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{reasoning}</ReactMarkdown>
+                <Markdown>{reasoning}</Markdown>
               </div>
             )}
           </div>
         )}
         {answer && (
           <div className="prose prose-sm dark:prose-invert">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{answer}</ReactMarkdown>
+            <Markdown>{answer}</Markdown>
           </div>
         )}
         <span className="text-xs text-gray-500">{time.split(",")[1]}</span>

--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+function CodeBlock({ inline, className, children, ...props }) {
+  const [copied, setCopied] = useState(false);
+  const code = String(children).replace(/\n$/, '');
+
+  if (inline) {
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  }
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1000);
+  };
+
+  return (
+    <div className="relative">
+      <pre>
+        <code className={className}>{code}</code>
+      </pre>
+      <button
+        onClick={handleCopy}
+        className="absolute top-1 right-1 text-xs bg-gray-200 dark:bg-gray-700 px-1 rounded"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+export default function Markdown({ children }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{ code: CodeBlock }}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -18,13 +18,14 @@ code {
   @apply bg-gray-100 text-gray-800 rounded px-1;
 }
 
-@media (prefers-color-scheme: dark) {
-  pre {
-    @apply bg-gray-800 text-gray-100;
-  }
-  code {
-    @apply bg-gray-800 text-gray-100;
-  }
+.dark pre,
+[data-theme="dark"] pre {
+  @apply bg-gray-800 text-gray-100;
+}
+
+.dark code,
+[data-theme="dark"] code {
+  @apply bg-gray-800 text-gray-100;
 }
 
 body[data-theme='dark'] {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
     "./public/index.html",


### PR DESCRIPTION
## Summary
- switch Tailwind to `dark` class based mode
- default to dark theme and set body class
- adjust code block styling for light mode
- add Markdown component with copyable code blocks
- show spinner only while reasoning is in progress

## Testing
- `npm install`
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684c8b408e008326a470ad1551ba734a