### PR TITLE
Fix route handler context typing

### DIFF
--- a/app/api/chat/[chatId]/messages/route.ts
+++ b/app/api/chat/[chatId]/messages/route.ts
@@ -1,21 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
+interface RouteContext<P extends Record<string, string | string[] | undefined>> {
+  params: Promise<P>;
+}
 import dbConnect from '@/lib/mongodb';
 import Chat from '@/models/Chat';
 import Message from '@/models/Message';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth';
-
-function getChatIdFromUrl(url: string) {
-  const pathParts = new URL(url).pathname.split('/');
-  return pathParts[3];
-}
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { chatId: string } }
+  { params }: RouteContext<{ chatId: string }>
 ) {
   try {
-    const chatId = getChatIdFromUrl(req.url);
+    const { chatId } = await params;
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -48,10 +46,10 @@ export async function GET(
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { chatId: string } }
+  { params }: RouteContext<{ chatId: string }>
 ) {
   try {
-    const chatId = getChatIdFromUrl(req.url);
+    const { chatId } = await params;
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/app/api/chat/[chatId]/route.ts
+++ b/app/api/chat/[chatId]/route.ts
@@ -1,21 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
+interface RouteContext<P extends Record<string, string | string[] | undefined>> {
+  params: Promise<P>;
+}
 import dbConnect from '@/lib/mongodb';
 import Chat from '@/models/Chat';
 import Message from '@/models/Message';
-import { getServerSession } from 'next-auth';
+import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth';
-
-function getChatIdFromUrl(url: string) {
-  const pathParts = new URL(url).pathname.split('/');
-  return pathParts[3];
-}
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { chatId: string } }
+  { params }: RouteContext<{ chatId: string }>
 ) {
   try {
-    const chatId = getChatIdFromUrl(req.url);
+    const { chatId } = await params;
     const session = await getServerSession(authOptions);
     if (!session || !session.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/hooks/useConversation.ts
+++ b/src/hooks/useConversation.ts
@@ -13,7 +13,7 @@ export default function useConversation(chatId: string | undefined) {
   const [loading, setLoading] = useState<boolean>(false);
   const [selectedModelType, setSelectedModelType] = useState<ModelType>('groq');
   const [selectedModel, setSelectedModel] = useState<string>('llama3-8b-8192');
-  const previousChatIdRef = useRef<string | undefined>();
+  const previousChatIdRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     const fetchMessages = async () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,9 @@
 import GoogleProvider from 'next-auth/providers/google';
 import { MongoDBAdapter } from "@auth/mongodb-adapter";
 import clientPromise from '@/lib/mongoClient';
+import type { NextAuthOptions } from 'next-auth';
 
-export const authOptions = {
+export const authOptions: NextAuthOptions = {
   adapter: MongoDBAdapter(clientPromise),
   providers: [
     GoogleProvider({

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 
-const MONGODB_URI = process.env.MONGODB_URI;
+const MONGODB_URI = process.env.MONGODB_URI as string;
 
 if (!MONGODB_URI) {
   throw new Error(
@@ -13,7 +13,17 @@ if (!MONGODB_URI) {
  * in development. This prevents connections from growing exponentially
  * during API Route usage.
  */
-let cached = global.mongoose;
+declare global {
+  var mongoose: {
+    conn: typeof import('mongoose') | null;
+    promise: Promise<typeof import('mongoose')> | null;
+  };
+}
+
+let cached: {
+  conn: typeof import('mongoose') | null;
+  promise: Promise<typeof import('mongoose')> | null;
+} = global.mongoose;
 
 if (!cached) {
   cached = global.mongoose = { conn: null, promise: null };

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,4 +1,5 @@
 import 'next-auth';
+import type { DefaultSession } from 'next-auth';
 
 declare module 'next-auth' {
   interface Session {
@@ -7,3 +8,5 @@ declare module 'next-auth' {
     } & DefaultSession['user'];
   }
 } 
+export {};
+


### PR DESCRIPTION
## Summary
- define a local `RouteContext` interface for app route handlers
- update dynamic API routes to use the new context
- move NextAuth session augmentation under `types`
- use `NextAuthOptions` for auth configuration
- adjust `useConversation` and MongoDB helper typings

## Testing
- `npm run type-check`
- `npm run lint` *(interrupted: interactive prompt)*
- `npm run build` *(fails: Invalid/Missing environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_686635f910088326b1dff4a6b66a79c6