### PR TITLE
Fix chat route change without full reload

### DIFF
--- a/src/app/chat/[chatId]/page.tsx
+++ b/src/app/chat/[chatId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, use } from "react";
+import { useState, useEffect, use, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import SideBar from "@/components/chat/SideBar";
 import ConversationContainer from "@/components/chat/ConversationContainer";
@@ -16,17 +16,18 @@ export default function ChatPage({ params }: { params: Promise<{ chatId: string 
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false);
   const [currentChatId, setCurrentChatId] = useState<string | undefined>(resolvedParams.chatId);
   const [conversationKey, setConversationKey] = useState<number>(Date.now());
+  const previousParamRef = useRef<string | undefined>(resolvedParams.chatId);
 
   useEffect(() => {
-    const previousChatId = currentChatId;
-    setCurrentChatId(resolvedParams.chatId);
-    
-    // Only update conversationKey if we're switching to a different existing chat
-    // Don't update when transitioning from 'new' to a real chat ID (same conversation)
-    if (previousChatId && previousChatId !== 'new' && resolvedParams.chatId !== previousChatId) {
-      setConversationKey(Date.now());
+    const previousChatId = previousParamRef.current;
+    if (resolvedParams.chatId !== previousChatId) {
+      setCurrentChatId(resolvedParams.chatId);
+      if (previousChatId && previousChatId !== 'new' && resolvedParams.chatId !== previousChatId) {
+        setConversationKey(Date.now());
+      }
+      previousParamRef.current = resolvedParams.chatId;
     }
-  }, [resolvedParams.chatId, currentChatId]);
+  }, [resolvedParams.chatId]);
 
   const toggleTheme = (): void => {
     setThemeMode((prev) => (prev === "light" ? "dark" : "light"));
@@ -72,7 +73,7 @@ export default function ChatPage({ params }: { params: Promise<{ chatId: string 
             transition={{ duration: 0.3 }}
             className="h-full"
           >
-            <ConversationContainer chatId={currentChatId} />
+            <ConversationContainer chatId={currentChatId} onNewChatId={setCurrentChatId} />
           </motion.div>
         </AnimatePresence>
       </div>

--- a/src/components/chat/ConversationContainer.tsx
+++ b/src/components/chat/ConversationContainer.tsx
@@ -9,10 +9,10 @@ import siteIcon from "../../assets/site-icon.png";
 import sampleData from "../../assets/sampleData.json";
 import useConversation from "../../hooks/useConversation";
 import clsx from "clsx";
-import { useRouter } from 'next/navigation';
 
 interface ConversationContainerProps {
   chatId?: string;
+  onNewChatId?: (id: string) => void;
 }
 
 interface ConversationStarter {
@@ -33,7 +33,7 @@ interface CustomSelectProps {
   placeholder?: string;
 }
 
-function ConversationContainer({ chatId }: ConversationContainerProps) {
+function ConversationContainer({ chatId, onNewChatId }: ConversationContainerProps) {
   const {
     messages,
     loading,
@@ -45,7 +45,6 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
     isStreaming,
     cancelStream,
   } = useConversation(chatId);
-  const router = useRouter();
 
   const [conversationStarters, setConversationStarters] = React.useState<ConversationStarter[]>([]);
 
@@ -71,7 +70,8 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
   const handleSend = async (question: string) => {
     const result = await sendMessage(question);
     if (result?.newChatId) {
-      router.replace(`/chat/${result.newChatId}`);
+      onNewChatId?.(result.newChatId);
+      window.history.replaceState(null, '', `/chat/${result.newChatId}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- avoid router navigation for newly created chats
- update ChatPage state when the chat ID is generated

## Testing
- `npm run type-check` *(fails: Cannot find module 'next')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868fe248b5083269f449d06baff9319