### PR TITLE
Fix chat URL update without page reload

### DIFF
--- a/src/app/chat/[chatId]/page.tsx
+++ b/src/app/chat/[chatId]/page.tsx
@@ -18,15 +18,23 @@ export default function ChatPage({ params }: { params: Promise<{ chatId: string 
   const [conversationKey, setConversationKey] = useState<number>(Date.now());
 
   useEffect(() => {
+    if (resolvedParams.chatId === "new") {
+      return;
+    }
+
     const previousChatId = currentChatId;
-    setCurrentChatId(resolvedParams.chatId);
-    
-    // Only update conversationKey if we're switching to a different existing chat
-    // Don't update when transitioning from 'new' to a real chat ID (same conversation)
-    if (previousChatId && previousChatId !== 'new' && resolvedParams.chatId !== previousChatId) {
+    if (resolvedParams.chatId !== currentChatId) {
+      setCurrentChatId(resolvedParams.chatId);
+    }
+
+    if (
+      previousChatId &&
+      previousChatId !== "new" &&
+      resolvedParams.chatId !== previousChatId
+    ) {
       setConversationKey(Date.now());
     }
-  }, [resolvedParams.chatId, currentChatId]);
+  }, [resolvedParams.chatId]);
 
   const toggleTheme = (): void => {
     setThemeMode((prev) => (prev === "light" ? "dark" : "light"));
@@ -72,7 +80,10 @@ export default function ChatPage({ params }: { params: Promise<{ chatId: string 
             transition={{ duration: 0.3 }}
             className="h-full"
           >
-            <ConversationContainer chatId={currentChatId} />
+            <ConversationContainer
+              chatId={currentChatId}
+              onNewChatId={setCurrentChatId}
+            />
           </motion.div>
         </AnimatePresence>
       </div>

--- a/src/components/chat/ConversationContainer.tsx
+++ b/src/components/chat/ConversationContainer.tsx
@@ -9,10 +9,10 @@ import siteIcon from "../../assets/site-icon.png";
 import sampleData from "../../assets/sampleData.json";
 import useConversation from "../../hooks/useConversation";
 import clsx from "clsx";
-import { useRouter } from 'next/navigation';
 
 interface ConversationContainerProps {
   chatId?: string;
+  onNewChatId?: (chatId: string) => void;
 }
 
 interface ConversationStarter {
@@ -33,7 +33,7 @@ interface CustomSelectProps {
   placeholder?: string;
 }
 
-function ConversationContainer({ chatId }: ConversationContainerProps) {
+function ConversationContainer({ chatId, onNewChatId }: ConversationContainerProps) {
   const {
     messages,
     loading,
@@ -45,7 +45,6 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
     isStreaming,
     cancelStream,
   } = useConversation(chatId);
-  const router = useRouter();
 
   const [conversationStarters, setConversationStarters] = React.useState<ConversationStarter[]>([]);
 
@@ -71,7 +70,10 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
   const handleSend = async (question: string) => {
     const result = await sendMessage(question);
     if (result?.newChatId) {
-      router.replace(`/chat/${result.newChatId}`);
+      window.history.replaceState(null, '', `/chat/${result.newChatId}`);
+      if (onNewChatId) {
+        onNewChatId(result.newChatId);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- allow `ConversationContainer` to notify when a new chat id is created
- update `ChatPage` to keep track of the new chat id and pass a callback
- change URL update logic to use `window.history.replaceState`

## Testing
- `npm run type-check` *(fails: Cannot find module 'next' or its corresponding type declarations)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868fe248b5083269f449d06baff9319