### PR TITLE
Fix chat navigation reload

### DIFF
--- a/src/components/chat/ConversationContainer.tsx
+++ b/src/components/chat/ConversationContainer.tsx
@@ -9,7 +9,6 @@ import siteIcon from "../../assets/site-icon.png";
 import sampleData from "../../assets/sampleData.json";
 import useConversation from "../../hooks/useConversation";
 import clsx from "clsx";
-import { useRouter } from 'next/navigation';
 
 interface ConversationContainerProps {
   chatId?: string;
@@ -45,7 +44,6 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
     isStreaming,
     cancelStream,
   } = useConversation(chatId);
-  const router = useRouter();
 
   const [conversationStarters, setConversationStarters] = React.useState<ConversationStarter[]>([]);
 
@@ -71,7 +69,10 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
   const handleSend = async (question: string) => {
     const result = await sendMessage(question);
     if (result?.newChatId) {
-      router.replace(`/chat/${result.newChatId}`);
+      // Using window.history.replaceState prevents a full page reload
+      // that was occurring with router.replace when transitioning
+      // from /chat/new to /chat/[chatId]
+      window.history.replaceState(null, '', `/chat/${result.newChatId}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- stop using `router.replace()` in `ConversationContainer` and instead
  manipulate the browser history directly to avoid a full page reload when the first message creates a new chat

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6868fe248b5083269f449d06baff9319