### PR TITLE
Fix initial chat navigation reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-The issue was that router.replace() in ConversationContainer.tsx:75 was causing a
-  page reload when transitioning from /chat/new to /chat/[chatId]. Using
-  window.history.replaceState() instead updates the URL without triggering a page reload.
-
-
-window.history.replaceState(null, '', `/chat/${result.newChatId}`);
-instead of useRouter we used the above. 
 # Bot AI - Next.js Application
 
-This is an AI chatbot application built with Next.js, featuring multiple AI model integrations including Groq, OpenRouter, and Perplexity models.
+This is an AI chatbot application built with Next.js, featuring multiple AI model
+integrations including Groq, OpenRouter, and Perplexity models.
+
+## Avoiding Page Reloads when Starting a Chat
+
+When sending the first message in a new conversation, the application updates the
+URL using `window.history.replaceState` instead of `router.replace`. This prevents
+the page from reloading when transitioning from `/chat/new` to `/chat/[chatId]`.
 
 ## Features
 

--- a/src/components/chat/ConversationContainer.tsx
+++ b/src/components/chat/ConversationContainer.tsx
@@ -71,7 +71,11 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
   const handleSend = async (question: string) => {
     const result = await sendMessage(question);
     if (result?.newChatId) {
-      router.replace(`/chat/${result.newChatId}`);
+      if (typeof window !== 'undefined') {
+        window.history.replaceState(null, '', `/chat/${result.newChatId}`);
+      } else {
+        router.replace(`/chat/${result.newChatId}`);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- prevent page reload when transitioning from `/chat/new` to `/chat/[chatId]`
- document the fix in README

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6868fe248b5083269f449d06baff9319