### PR TITLE
Fix page reload on first message

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/src/components/chat/ConversationContainer.tsx
+++ b/src/components/chat/ConversationContainer.tsx
@@ -71,7 +71,8 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
   const handleSend = async (question: string) => {
     const result = await sendMessage(question);
     if (result?.newChatId) {
-      router.replace(`/chat/${result.newChatId}`);
+      // Update the URL without triggering a full page reload
+      window.history.replaceState(null, '', `/chat/${result.newChatId}`);
     }
   };
 
@@ -209,7 +210,7 @@ function ConversationContainer({ chatId }: ConversationContainerProps) {
                   How Can I Help You Today?
                 </h2>
                 <p className="text-lg mb-4" style={{ color: "var(--text-secondary)" }}>
-                  Ask me anything, and I'll provide detailed, helpful responses
+                  Ask me anything, and I&apos;ll provide detailed, helpful responses
                 </p>
                 {selectedModel && (
                   <div className="flex items-center justify-center gap-2 text-sm" style={{ color: "var(--text-secondary)" }}>


### PR DESCRIPTION
## Summary
- use `window.history.replaceState` to avoid reload on first chat message
- escape apostrophe in chat intro text
- add minimal ESLint config

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_686bb1d225848326906db5dc7738d25a